### PR TITLE
Update DynamicInheritancePermissionLogic.java

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/resource/DynamicInheritancePermissionLogic.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/resource/DynamicInheritancePermissionLogic.java
@@ -70,7 +70,7 @@ public class DynamicInheritancePermissionLogic
 			_parentModelResourcePermission.contains(
 				permissionChecker, parent, ActionKeys.ACCESS)) {
 
-			return null;
+			return true;
 		}
 
 		if (_parentModelResourcePermission.contains(


### PR DESCRIPTION
If parent model has access permissions and _checkParentAccess is true, the logic must return true because the resource can be accessed because the parent resource can be accessed too